### PR TITLE
Add recursive scraping of "Two Peas" main dishes

### DIFF
--- a/recipe_scraper/spiders/twopeasandtheirpod.py
+++ b/recipe_scraper/spiders/twopeasandtheirpod.py
@@ -27,3 +27,8 @@ class TwopeasandtheirpodSpider(scrapy.Spider):
             if links:
                 for link in links:
                     yield scrapy.Request(link, callback=self.parse)
+
+            # Use CSS selectors to find the next page button
+            nextPage = response.css("div#wp_page_numbers").css("a:contains('>') ::attr(href)").extract_first()
+            if nextPage:
+                yield scrapy.Request(nextPage, callback=self.parse)


### PR DESCRIPTION
The spider will look for the next page button (">") at the bottom of the
recipe, and add it to the pages to scrape. This allows the spider to
cover the entire main dishes category by starting from the first page.

Seems to introduce the unintended effect of scraping non-"main dish"
pages from earlier recipes, which may be a bug.

Resolves: #1